### PR TITLE
Php 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "~7.2|~7.3|~7.4",
+    "php": "~7.2|~7.3|~7.4|~8.1",
     "psr/log": "^1.0",
     "beberlei/assert": "^2.4|^3.0",
     "regex-guard/regex-guard": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "~7.2|~7.3|~7.4|~8.1",
+    "php": "~7.2|~7.3|~7.4",
     "psr/log": "^1.0",
     "beberlei/assert": "^2.4|^3.0",
     "regex-guard/regex-guard": "^1.1"


### PR DESCRIPTION
This adds PHP 8.1 to the list of supported versions.

Signed-Off-By: Rolf Krämer <rolf.kraemer@camao.one>